### PR TITLE
add How-to-use-github lecture from computation thinking

### DIFF
--- a/template.html
+++ b/template.html
@@ -18,6 +18,7 @@
         <li><a target="_blank" rel="noopener" href="https://github.com/miguelraz/StartHere.jl">StartHere.jl</a> by <a target="_blank" rel="noopener" href="https://twitter.com/miguelraz_">Miguel Raz Guzmán</a></li>
         <li><a target="_blank" rel="noopener" href="https://www.youtube.com/watch?v=QVmU29rCjaA">Developing Julia Packages</a> by <a target="_blank" rel="noopener" href="https://twitter.com/chrisrackauckas">Chris Rackauckas</a></li>
         <li><a target="_blank" rel="noopener" href="https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source">An Introduction to Open Source</a> by <a target="_blank" rel="noopener" href="https://twitter.com/lisaironcutter">Lisa Tagliaferri</a> and <a target="_blank" rel="noopener" href="https://twitter.com/lynmuldrow">Lyn Muldrow</a></li>
+        <li><a target="_blank" rel="noopener" href="https://computationalthinking.mit.edu/Spring21/how_to_collaborate_on_software/">How (and why) to use GitHub</a> by <a target="_blank" rel="noopener" href="https://github.com/fonsp">Fons van der Plas</a> and <a target="_blank" rel="noopener" href="https://math.mit.edu/directory/profile.php?pid=63">Alan Edelman</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
Adding a link to to a lecture from our course:

https://computationalthinking.mit.edu/Spring21/how_to_collaborate_on_software/

The goal is:
- what is git, why don’t we use Google Drive for software?
- how to make a simple documentation PR to a julia package on github.com (on the website, without cloning)
- how to use github (github desktop, so without the terminal)

I gave the lecture because I felt like the world is missing a “modern” guide to git that does not use a terminal, and that compares it to google drive. This should make it more accessible to students who only recently started using computers and programming.